### PR TITLE
styling탭 아이템 선택 창 변경 (21.10.29나연)

### DIFF
--- a/ClosetApplication/.idea/misc.xml
+++ b/ClosetApplication/.idea/misc.xml
@@ -45,11 +45,13 @@
         <entry key="app/src/main/res/layout/fragment_closet.xml" value="0.33" />
         <entry key="app/src/main/res/layout/fragment_home.xml" value="0.1828774062816616" />
         <entry key="app/src/main/res/layout/fragment_mypage.xml" value="0.1828774062816616" />
-        <entry key="app/src/main/res/layout/fragment_styling.xml" value="0.1828774062816616" />
+        <entry key="app/src/main/res/layout/fragment_styling.xml" value="0.33" />
+        <entry key="app/src/main/res/layout/header_footer.xml" value="0.31354166666666666" />
         <entry key="app/src/main/res/layout/main_detail_for_viewpager.xml" value="0.1828774062816616" />
         <entry key="app/src/main/res/layout/main_layout.xml" value="0.1828774062816616" />
         <entry key="app/src/main/res/layout/recommended_item_list.xml" value="0.1828774062816616" />
         <entry key="app/src/main/res/layout/select_item.xml" value="0.1828774062816616" />
+        <entry key="app/src/main/res/layout/sideStylingRecyclerView.xml" value="0.31354166666666666" />
         <entry key="app/src/main/res/layout/viewholder_gallery_photo_item.xml" value="0.25" />
         <entry key="app/src/main/res/layout/viewholder_item.xml" value="0.21197916666666666" />
         <entry key="app/src/main/res/layout/viewholder_item_styling.xml" value="0.21197916666666666" />

--- a/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/closet/ClosetFragment.kt
+++ b/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/closet/ClosetFragment.kt
@@ -55,7 +55,7 @@ class ClosetFragment : Fragment(R.layout.fragment_closet) {
 
         Log.d("bb","onViewCreated")
         initViews(view, fragmentClosetBinding)
-        //viewModel.fetchData()
+//        viewModel.fetchData()
         observeState()
     }
 
@@ -165,11 +165,11 @@ class ClosetFragment : Fragment(R.layout.fragment_closet) {
 
         Log.d("bb","resume")
         viewModel.fetchData()
+        observeState()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         Log.d("bb","destroy")
-      //  viewModel.
     }
 }

--- a/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/closet/itemViewModel.kt
+++ b/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/closet/itemViewModel.kt
@@ -31,6 +31,7 @@ class itemViewModel : ViewModel() {
         setState(
             ItemState.Loading
         )
+
         itemList = db.collection(DBkey.DB_USERS).document(user)
             .collection(DBkey.DB_ITEM).get().await()
             .toObjects(ItemModel::class.java)
@@ -91,5 +92,10 @@ class itemViewModel : ViewModel() {
                 photoList = itemList.filter { it.isSelected }
             )
         )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Log.d("bb","clear")
     }
 }

--- a/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/styling/stylingItemAdapter.kt
+++ b/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/styling/stylingItemAdapter.kt
@@ -1,10 +1,9 @@
 package com.nanioi.closetapplication.styling
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.nanioi.closetapplication.R
 import com.nanioi.closetapplication.closet.ItemModel
@@ -12,14 +11,16 @@ import com.nanioi.closetapplication.databinding.ViewholderItemStylingBinding
 import com.nanioi.closetapplication.extensions.loadCenterCrop
 
 class stylingItemAdapter(
-    val onItemClicked: (ItemModel) -> Unit
-) : ListAdapter<ItemModel, stylingItemAdapter.ViewHolder>(diffUtil) {
+    private val onItemClicked: (ItemModel) -> Unit
+) : RecyclerView.Adapter<stylingItemAdapter.ViewHolder>() {
 
+    private var itemList : List<ItemModel> = listOf()
 
-    inner class ViewHolder(private val binding: ViewholderItemStylingBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class ViewHolder(
+        private val binding: ViewholderItemStylingBinding
+        ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(item: ItemModel)= with(binding) {
-
+        fun bindData(item: ItemModel) = with(binding) {
             photoImageView.loadCenterCrop(item.imageUrl, 8f)
             checkButton.setImageDrawable(
                 ContextCompat.getDrawable(
@@ -30,8 +31,11 @@ class stylingItemAdapter(
                         R.drawable.ic_before_check
                 )
             )
-            binding.root.setOnClickListener {
-                onItemClicked(item)
+        }
+
+        fun bindViews(data: ItemModel) = with(binding) {
+            root.setOnClickListener {
+                onItemClicked(data)
             }
         }
     }
@@ -40,20 +44,16 @@ class stylingItemAdapter(
         return ViewHolder(ViewholderItemStylingBinding.inflate(LayoutInflater.from(parent.context), parent, false))
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(currentList[position])
+    override fun onBindViewHolder(holder: stylingItemAdapter.ViewHolder, position: Int) {
+        holder.bindData(itemList[position])
+        holder.bindViews(itemList[position])
     }
+    override fun getItemCount(): Int = itemList.size
 
-    companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<ItemModel>() {
-            override fun areItemsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
-                return oldItem.itemId == newItem.itemId
-            }
 
-            override fun areContentsTheSame(oldItem: ItemModel, newItem: ItemModel): Boolean {
-                return oldItem == newItem
-            }
-
-        }
+    fun setPhotoList(itemList: List<ItemModel>) {
+        Log.d("bb","setPhotoList")
+        this.itemList = itemList
+        notifyDataSetChanged()
     }
 }

--- a/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/styling/stylingItemViewModel.kt
+++ b/ClosetApplication/app/src/main/java/com/nanioi/closetapplication/styling/stylingItemViewModel.kt
@@ -20,15 +20,15 @@ class stylingItemViewModel :ViewModel() {
     val user = Firebase.auth.currentUser!!.uid
 
     var itemList = mutableListOf<ItemModel>()
-    //private var _stylingItem = MutableLiveData<ItemModel>()
-    //val stylingItem : LiveData<ItemModel> = _stylingItem
     private var _itemStateLiveData = MutableLiveData<stylingState>(stylingState.Uninitialized)
     val itemStateLiveData : LiveData<stylingState> = _itemStateLiveData
 
     fun fetchData() = viewModelScope.launch {
+        Log.d("aaa","fetch")
         itemList = db.collection(DBkey.DB_USERS).document(user)
             .collection(DBkey.DB_ITEM).get().await()
             .toObjects(ItemModel::class.java)
+
         setState(
             stylingState.Success(
                 photoList = itemList
@@ -36,7 +36,7 @@ class stylingItemViewModel :ViewModel() {
         )
     }
     fun selectPhoto(item: ItemModel) {
-        Log.d("bb","select")
+        Log.d("aaa","select")
         val findItem = itemList.find { it.itemId == item.itemId }
         findItem?.let { photo ->
             itemList[itemList.indexOf(photo)] =
@@ -51,11 +51,11 @@ class stylingItemViewModel :ViewModel() {
         }
     }
     private fun setState(state: stylingState) {
-        Log.d("bb","setState")
+        Log.d("aaa","setState")
         _itemStateLiveData.postValue(state)
     }
     fun confirmCheckedPhotos() {
-        Log.d("bb","confirm")
+        Log.d("aaa","confirm")
         val findItem = itemList.find { it.isSelected == true }
         findItem?.let { item->
             setState(
@@ -64,5 +64,10 @@ class stylingItemViewModel :ViewModel() {
                 )
             )
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        Log.d("aaa","clear")
     }
 }

--- a/ClosetApplication/app/src/main/res/layout/fragment_styling.xml
+++ b/ClosetApplication/app/src/main/res/layout/fragment_styling.xml
@@ -83,74 +83,54 @@
             app:layout_constraintBottom_toBottomOf="@+id/person_image"
             app:layout_constraintStart_toStartOf="parent" />
 
-        <HorizontalScrollView
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/selectItemTap"
             android:layout_width="match_parent"
             android:layout_height="430dp"
             android:layout_gravity="center"
-            android:layout_marginHorizontal="20dp"
-            android:background="@drawable/border"
+            android:layout_marginHorizontal="10dp"
+            android:background="@drawable/radius_border"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.491">
+            app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/itemRecycleView"
+                android:layout_width="wrap_content"
+                android:layout_height="300dp"
+                android:layout_gravity="center"
+                android:layout_marginHorizontal="15dp"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="15dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/backButton" />
 
-                <ImageView
-                    android:id="@+id/uploadPhoto"
-                    android:layout_width="200dp"
-                    android:layout_height="300dp"
-                    android:layout_gravity="center"
-                    android:layout_marginStart="15dp"
-                    android:layout_marginTop="10dp"
-                    android:background="@drawable/radius_border"
-                    android:scaleType="center"
-                    android:src="@drawable/ic_baseline_add_a_photo_24"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/backButton" />
+            <Button
+                android:id="@+id/selectItemButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="30dp"
+                android:text="선택완료"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/itemRecycleView"
+                tools:ignore="HardcodedText" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/itemRecycleView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="300dp"
-                    android:layout_gravity="center"
-                    android:layout_marginEnd="15dp"
-                    android:orientation="horizontal"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/uploadPhoto"
-                    app:layout_constraintTop_toTopOf="@+id/uploadPhoto" />
+            <ImageButton
+                android:id="@+id/backButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="10dp"
+                android:background="@drawable/ic_baseline_close_24"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-                <Button
-                    android:id="@+id/selectItemButton"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="30dp"
-                    android:layout_marginTop="10dp"
-                    android:text="선택완료"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/uploadPhoto"
-                    tools:ignore="HardcodedText" />
-
-                <ImageButton
-                    android:id="@+id/backButton"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="10dp"
-                    android:background="@drawable/ic_baseline_close_24"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </HorizontalScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
- 사진으로 아이템 추가하는 기능 제거, 갤러리(closet에서 저장한 사진) 선택하는 방법으로 변경
- 이유 : 스크롤뷰안에 리사이클러뷰 (중복 스크롤) 불가
=> 아이템은 모두 불러와 지지만 화면 상 보여지는 2개까지만 보이는 문제, 따로따로 스크롤 되는 등 문제 발생
- nestedScroll , behavior로 구현시도 -> 비효율적, 문제많음
- 추후 해결방안을 찾고 시간여유가 된다면 사진으로 아이템 추가 기능 추가할 예정